### PR TITLE
Change version dependency to allow railties 4.0

### DIFF
--- a/dependent-fields-rails.gemspec
+++ b/dependent-fields-rails.gemspec
@@ -9,5 +9,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'jquery-rails'
   s.add_dependency 'coffee-rails'
-  s.add_dependency "railties", "~> 4.0"
+  s.add_dependency "railties", ">= 3.1"
 end

--- a/dependent-fields-rails.gemspec
+++ b/dependent-fields-rails.gemspec
@@ -9,5 +9,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'jquery-rails'
   s.add_dependency 'coffee-rails'
-  s.add_dependency "railties", "~> 3.1"
+  s.add_dependency "railties", "~> 4.0"
 end


### PR DESCRIPTION
I'm not an expert at the best practices for gem dependencies, but it seems like allowing future major versions is a reasonable bet, since all that is being used is the Rails::Engine class to trigger the asset pipeline. 

This makes the gem work for me with Rails 4.0.
