### PR TITLE
Update README.md, adding missing close-parenthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Installation
 
         $(document).ready(function() {
             DependentFields.bind()
-        }
+        });
 
 1. Restart your server and everything should be set up. See Usage below on how to declare your dependent fields in views.
 


### PR DESCRIPTION
The code example of binding events with jquery was missing the close-parenthesis around the function.
