### PR TITLE
Make select2 optional and uncheck hidden fields

### DIFF
--- a/vendor/assets/javascripts/dependent-fields.js.coffee
+++ b/vendor/assets/javascripts/dependent-fields.js.coffee
@@ -18,6 +18,7 @@ toggle = ($parent, showOrHide, method, duration) ->
       $parent.find('.select2').select2('disable') if $.fn.select2
     else
       $parent.hide(duration)
+      $parent.find('input:checked').prop('checked', false)
 
 
 showOrHideDependentFieldsSelect = (duration = 'fast') ->

--- a/vendor/assets/javascripts/dependent-fields.js.coffee
+++ b/vendor/assets/javascripts/dependent-fields.js.coffee
@@ -8,14 +8,14 @@ toggle = ($parent, showOrHide, method, duration) ->
     if method == 'disable'
       # use attr instead of prop, because prop does not work with twitter bootstrap button
       $parent.find('input,textarea,select,button,.btn').removeAttr('disabled')
-      $parent.find('.select2').select2('enable')
+      $parent.find('.select2').select2('enable') if $.fn.select2
     else
       $parent.show(duration)
   else
     if method == 'disable'
       # use attr instead of prop, because prop does not work with twitter bootstrap button
       $parent.find('input,textarea,select,button,.btn').attr('disabled', 'disabled')
-      $parent.find('.select2').select2('disable')
+      $parent.find('.select2').select2('disable') if $.fn.select2
     else
       $parent.hide(duration)
 


### PR DESCRIPTION
I didn't see any dependencies on select2, so I added a check for it.

I also have a requirement to reset/uncheck any checkboxes in the hidden dependent fields. I wasn't sure if this is something you would want or if there's some more customizable way to allow it, so I'm open to any suggestions.

Lastly, I can break these into 2 separate pull requests if you want.
