### PR TITLE
Improve

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ You can also specify multiple option values by seperating them with `|`. For exa
 
 Add `data-method='disable'` to the js-dependent-fields div.
 
+**Note:** The default is now hide and disable the fields and enable them on again when showing. This is to prevent the hidden dependent fields from being submitted. The old behavior can be archived when add `data-method='hide'` to the js-dependent-fields div.
 
 
 Minimal Demo

--- a/vendor/assets/javascripts/dependent-fields.js.coffee
+++ b/vendor/assets/javascripts/dependent-fields.js.coffee
@@ -5,19 +5,19 @@
 
 toggle = ($parent, showOrHide, method, duration) ->
   if showOrHide
-    if method == 'disable'
+    if method != 'hide' # disable or default
       # use attr instead of prop, because prop does not work with twitter bootstrap button
       $parent.find('input,textarea,select,button,.btn').removeAttr('disabled')
       $parent.find('.select2').select2('enable') if $.fn.select2
-    else
+    if method != 'disable' # hide or default
       $parent.find('input[data-dependent-fields-required],textarea[data-dependent-fields-required],select[data-dependent-fields-required]').attr('required', 'required')
       $parent.show(duration)
   else
-    if method == 'disable'
+    if method != 'hide' # disable or default
       # use attr instead of prop, because prop does not work with twitter bootstrap button
       $parent.find('input,textarea,select,button,.btn').attr('disabled', 'disabled')
       $parent.find('.select2').select2('disable') if $.fn.select2
-    else
+    if method != 'disable' # hide or default
       $parent.find('input[required],textarea[required],select[required]').removeAttr('required').attr('data-dependent-fields-required', 'required')
       $parent.hide(duration)
 

--- a/vendor/assets/javascripts/dependent-fields.js.coffee
+++ b/vendor/assets/javascripts/dependent-fields.js.coffee
@@ -10,6 +10,7 @@ toggle = ($parent, showOrHide, method, duration) ->
       $parent.find('input,textarea,select,button,.btn').removeAttr('disabled')
       $parent.find('.select2').select2('enable') if $.fn.select2
     else
+      $parent.find('input[data-dependent-fields-required],textarea[data-dependent-fields-required],select[data-dependent-fields-required]').attr('required', 'required')
       $parent.show(duration)
   else
     if method == 'disable'
@@ -17,6 +18,7 @@ toggle = ($parent, showOrHide, method, duration) ->
       $parent.find('input,textarea,select,button,.btn').attr('disabled', 'disabled')
       $parent.find('.select2').select2('disable') if $.fn.select2
     else
+      $parent.find('input[required],textarea[required],select[required]').removeAttr('required').attr('data-dependent-fields-required', 'required')
       $parent.hide(duration)
 
 

--- a/vendor/assets/javascripts/dependent-fields.js.coffee
+++ b/vendor/assets/javascripts/dependent-fields.js.coffee
@@ -16,7 +16,8 @@ toggle = ($parent, showOrHide, method, duration) ->
       $fieldsAndBtns.filter('[data-dependent-fields-disabled=no]').removeAttr('disabled')
       if $.fn.select2
         $select2 = $parentVisible.find('.select2')
-        $select2.filter('[data-dependent-fields-disabled=no]').select2('enable')
+        $select2disabled = $select2.filter('[data-dependent-fields-disabled=no]')
+        $select2disabled.select2('enable') if $select2disabled.length > 0
         $select2.removeAttr('data-dependent-fields-disabled')
       $fieldsAndBtns.removeAttr('data-dependent-fields-disabled')
     if method != 'disable' # hide or default
@@ -32,7 +33,9 @@ toggle = ($parent, showOrHide, method, duration) ->
       # disable things
       # use attr instead of prop, because prop does not work with twitter bootstrap button
       $parent.find(fieldsAndBtnsSelector).attr('disabled', 'disabled')
-      $parent.find('.select2').select2('disable') if $.fn.select2
+      if $.fn.select2
+        $select2enabled = $parent.find('.select2')
+        $select2enabled.select2('disable') if $select2enabled.length > 0
     if method != 'disable' # hide or default
       $parent.find(fieldsSelector).filter('[required]').removeAttr('required').attr('data-dependent-fields-required', 'required')
       $parent.hide(duration)

--- a/vendor/assets/javascripts/dependent-fields.js.coffee
+++ b/vendor/assets/javascripts/dependent-fields.js.coffee
@@ -14,11 +14,11 @@ toggle = ($parent, showOrHide, method, duration) ->
       # use attr instead of prop, because prop does not work with twitter bootstrap button
       $fieldsAndBtns = $parentVisible.find(fieldsAndBtnsSelector)
       $fieldsAndBtns.filter('[data-dependent-fields-disabled=no]').removeAttr('disabled')
-      $fieldsAndBtns.removeAttr('data-dependent-fields-disabled')
       if $.fn.select2
         $select2 = $parentVisible.find('.select2')
         $select2.filter('[data-dependent-fields-disabled=no]').select2('enable')
         $select2.removeAttr('data-dependent-fields-disabled')
+      $fieldsAndBtns.removeAttr('data-dependent-fields-disabled')
     if method != 'disable' # hide or default
       $parentVisible.find(fieldsSelector).filter('[data-dependent-fields-required]').attr('required', 'required')
       $parent.show(duration)

--- a/vendor/assets/javascripts/dependent-fields.js.coffee
+++ b/vendor/assets/javascripts/dependent-fields.js.coffee
@@ -5,20 +5,20 @@
 
 toggle = ($parent, showOrHide, method, duration) ->
   fieldsSelector = 'input,textarea,select'
-  fieldsAndBtnsSelector = 'input,textarea,select,button,.btn'
+  fieldsAndBtnsSelector = fieldsSelector+',button'
   parentVisibleSelector = ':not(.js-dependent-fields-hidden)'
   if showOrHide
     $parent.removeClass 'js-dependent-fields-hidden'
     $parentVisible = $parent.find(parentVisibleSelector)
     if method != 'hide' # disable or default
-      # use attr instead of prop, because prop does not work with twitter bootstrap button
       $fieldsAndBtns = $parentVisible.find(fieldsAndBtnsSelector)
-      $fieldsAndBtns.filter('[data-dependent-fields-disabled=no]').removeAttr('disabled')
-      if $.fn.select2
-        $select2 = $parentVisible.find('.select2')
-        $select2.filter('[data-dependent-fields-disabled=no]').prop('disabled', false)
-        $select2.removeAttr('data-dependent-fields-disabled')
+      # only enable if it was enabled before hiding
+      $fieldsAndBtns.filter("[data-dependent-fields-disabled='no']").prop('disabled', false)
       $fieldsAndBtns.removeAttr('data-dependent-fields-disabled')
+      # use attr instead of prop, because prop does not work with twitter bootstrap button
+      $parentVisible.find(".btn[data-dependent-fields-disabled='no']").removeAttr('disabled')
+      # remove the disabled state
+      $parentVisible.find('[data-dependent-fields-disabled]').removeAttr('data-dependent-fields-disabled')
     if method != 'disable' # hide or default
       $parentVisible.find(fieldsSelector).filter('[data-dependent-fields-required]').attr('required', 'required')
       $parent.show(duration)
@@ -26,13 +26,13 @@ toggle = ($parent, showOrHide, method, duration) ->
     $parent.addClass 'js-dependent-fields-hidden'
     if method != 'hide' # disable or default
       # store the disabled state
-      $fieldsAndBtns = $parent.find(fieldsAndBtnsSelector+',.select2').not('[data-dependent-fields-disabled]')
-      $fieldsAndBtns.filter('[disabled]').attr('data-dependent-fields-disabled', 'yes')
-      $fieldsAndBtns.not('[disabled]').attr('data-dependent-fields-disabled', 'no')
+      $fieldsAndBtns = $parent.find(fieldsAndBtnsSelector + ', .btn').not('[data-dependent-fields-disabled]')
+      $fieldsAndBtns.filter(':disabled').attr('data-dependent-fields-disabled', 'yes')
+      $fieldsAndBtns.not(':disabled').attr('data-dependent-fields-disabled', 'no')
       # disable things
+      $fieldsAndBtns.filter(fieldsAndBtnsSelector).prop('disabled', true)
       # use attr instead of prop, because prop does not work with twitter bootstrap button
-      $parent.find(fieldsAndBtnsSelector).attr('disabled', 'disabled')
-      $parent.find('.select2').prop('disabled', 'disabled') if $.fn.select2
+      $fieldsAndBtns.not(fieldsAndBtnsSelector).attr('disabled', 'disabled')
     if method != 'disable' # hide or default
       $parent.find(fieldsSelector).filter('[required]').removeAttr('required').attr('data-dependent-fields-required', 'required')
       $parent.hide(duration)

--- a/vendor/assets/javascripts/dependent-fields.js.coffee
+++ b/vendor/assets/javascripts/dependent-fields.js.coffee
@@ -6,17 +6,30 @@
 toggle = ($parent, showOrHide, method, duration) ->
   fieldsSelector = 'input,textarea,select'
   fieldsAndBtnsSelector = 'input,textarea,select,button,.btn'
+  parentVisibleSelector = ':not(.js-dependent-fields-hidden)'
   if showOrHide
-    $parentVisible = $parent.find(':not(.js-dependent-fields:hidden)')
+    $parent.removeClass 'js-dependent-fields-hidden'
+    $parentVisible = $parent.find(parentVisibleSelector)
     if method != 'hide' # disable or default
       # use attr instead of prop, because prop does not work with twitter bootstrap button
-      $parentVisible.find(fieldsAndBtnsSelector).removeAttr('disabled')
-      $parentVisible.find('.select2').select2('enable') if $.fn.select2
+      $fieldsAndBtns = $parentVisible.find(fieldsAndBtnsSelector)
+      $fieldsAndBtns.filter('[data-dependent-fields-disabled=no]').removeAttr('disabled')
+      $fieldsAndBtns.removeAttr('data-dependent-fields-disabled')
+      if $.fn.select2
+        $select2 = $parentVisible.find('.select2')
+        $select2.filter('[data-dependent-fields-disabled=no]').select2('enable')
+        $select2.removeAttr('data-dependent-fields-disabled')
     if method != 'disable' # hide or default
       $parentVisible.find(fieldsSelector).filter('[data-dependent-fields-required]').attr('required', 'required')
       $parent.show(duration)
   else
+    $parent.addClass 'js-dependent-fields-hidden'
     if method != 'hide' # disable or default
+      # store the disabled state
+      $fieldsAndBtns = $parent.find(fieldsAndBtnsSelector+',.select2').not('[data-dependent-fields-disabled]')
+      $fieldsAndBtns.filter('[disabled]').attr('data-dependent-fields-disabled', 'yes')
+      $fieldsAndBtns.not('[disabled]').attr('data-dependent-fields-disabled', 'no')
+      # disable things
       # use attr instead of prop, because prop does not work with twitter bootstrap button
       $parent.find(fieldsAndBtnsSelector).attr('disabled', 'disabled')
       $parent.find('.select2').select2('disable') if $.fn.select2

--- a/vendor/assets/javascripts/dependent-fields.js.coffee
+++ b/vendor/assets/javascripts/dependent-fields.js.coffee
@@ -4,21 +4,24 @@
 
 
 toggle = ($parent, showOrHide, method, duration) ->
+  fieldsSelector = 'input,textarea,select'
+  fieldsAndBtnsSelector = 'input,textarea,select,button,.btn'
   if showOrHide
+    $parentVisible = $parent.find(':not(.js-dependent-fields:hidden)')
     if method != 'hide' # disable or default
       # use attr instead of prop, because prop does not work with twitter bootstrap button
-      $parent.find('input,textarea,select,button,.btn').removeAttr('disabled')
-      $parent.find('.select2').select2('enable') if $.fn.select2
+      $parentVisible.find(fieldsAndBtnsSelector).removeAttr('disabled')
+      $parentVisible.find('.select2').select2('enable') if $.fn.select2
     if method != 'disable' # hide or default
-      $parent.find('input[data-dependent-fields-required],textarea[data-dependent-fields-required],select[data-dependent-fields-required]').attr('required', 'required')
+      $parentVisible.find(fieldsSelector).filter('[data-dependent-fields-required]').attr('required', 'required')
       $parent.show(duration)
   else
     if method != 'hide' # disable or default
       # use attr instead of prop, because prop does not work with twitter bootstrap button
-      $parent.find('input,textarea,select,button,.btn').attr('disabled', 'disabled')
+      $parent.find(fieldsAndBtnsSelector).attr('disabled', 'disabled')
       $parent.find('.select2').select2('disable') if $.fn.select2
     if method != 'disable' # hide or default
-      $parent.find('input[required],textarea[required],select[required]').removeAttr('required').attr('data-dependent-fields-required', 'required')
+      $parent.find(fieldsSelector).filter('[required]').removeAttr('required').attr('data-dependent-fields-required', 'required')
       $parent.hide(duration)
 
 

--- a/vendor/assets/javascripts/dependent-fields.js.coffee
+++ b/vendor/assets/javascripts/dependent-fields.js.coffee
@@ -77,21 +77,15 @@ showOrHideDependentFieldsRadio = (duration = 'fast') ->
 
 bind = ->
   $selects = $('select')
-  $selects.not('[data-important]').each _.partial(showOrHideDependentFieldsSelect, 0)
-  $selects.filter('[data-important]').each _.partial(showOrHideDependentFieldsSelect, 0)
-
+  $selects.each _.partial(showOrHideDependentFieldsSelect, 0)
   $selects.change showOrHideDependentFieldsSelect
 
   $inputs = $('input[type=checkbox]')
-  $inputs.not('[data-important]').each _.partial(showOrHideDependentFieldsCheckbox, 0)
-  $inputs.filter('[data-important]').each _.partial(showOrHideDependentFieldsCheckbox, 0)
-
+  $inputs.each _.partial(showOrHideDependentFieldsCheckbox, 0)
   $inputs.change showOrHideDependentFieldsCheckbox
 
   $radios = $('input[type=radio]')
-  $radios.not('[data-important]').each _.partial(showOrHideDependentFieldsRadio, 0)
-  $radios.filter('[data-important]').each _.partial(showOrHideDependentFieldsRadio, 0)
-
+  $radios.each _.partial(showOrHideDependentFieldsRadio, 0)
   $radios.change showOrHideDependentFieldsRadio
 
 

--- a/vendor/assets/javascripts/dependent-fields.js.coffee
+++ b/vendor/assets/javascripts/dependent-fields.js.coffee
@@ -16,8 +16,7 @@ toggle = ($parent, showOrHide, method, duration) ->
       $fieldsAndBtns.filter('[data-dependent-fields-disabled=no]').removeAttr('disabled')
       if $.fn.select2
         $select2 = $parentVisible.find('.select2')
-        $select2disabled = $select2.filter('[data-dependent-fields-disabled=no]')
-        $select2disabled.select2('enable') if $select2disabled.length > 0
+        $select2.filter('[data-dependent-fields-disabled=no]').prop('disabled', false)
         $select2.removeAttr('data-dependent-fields-disabled')
       $fieldsAndBtns.removeAttr('data-dependent-fields-disabled')
     if method != 'disable' # hide or default
@@ -33,9 +32,7 @@ toggle = ($parent, showOrHide, method, duration) ->
       # disable things
       # use attr instead of prop, because prop does not work with twitter bootstrap button
       $parent.find(fieldsAndBtnsSelector).attr('disabled', 'disabled')
-      if $.fn.select2
-        $select2enabled = $parent.find('.select2')
-        $select2enabled.select2('disable') if $select2enabled.length > 0
+      $parent.find('.select2').prop('disabled', 'disabled') if $.fn.select2
     if method != 'disable' # hide or default
       $parent.find(fieldsSelector).filter('[required]').removeAttr('required').attr('data-dependent-fields-required', 'required')
       $parent.hide(duration)


### PR DESCRIPTION
Have done some improvments
- store and remove the html5 required attribute when the dependent-field is hidden (This could the form from submitting with no proper error messages for the user)
- Change the default behavier to hide and disable (This prevents the hidden fields from beeing submitted), old behavier is still archivable
- store the disabled status before hiding and restore when show
- clean up the `filter('[data-important]')` and `not('[data-important]')` (Can't see way they are usefull? Will initialize anyway, so remove them)

sorry for putting everything together in a big pull request. If you have questions or just want to pull in parts feel free to do so.
